### PR TITLE
lib7zip.h: fix compilation under Windows (MSVC2017)

### DIFF
--- a/src/lib7zip.h
+++ b/src/lib7zip.h
@@ -17,11 +17,11 @@
 #ifndef __int64
 #define __int64 long long int
 #endif
-typedef std::basic_string<wchar_t> wstring;
-typedef std::basic_string<char> string;
 #ifndef CLASS_E_CLASSNOTAVAILABLE
 #define CLASS_E_CLASSNOTAVAILABLE (0x80040111L)
 #endif
+#endif
+
 #define FILE_BEGIN           0
 #define FILE_CURRENT         1
 #define FILE_END             2
@@ -29,10 +29,8 @@ typedef std::basic_string<char> string;
 #ifndef S_OK
 #define S_OK 				 0
 #endif
-#else
 typedef std::basic_string<wchar_t> wstring;
 typedef std::basic_string<char> string;
-#endif
 
 typedef std::vector<wstring> WStringArray;
 


### PR DESCRIPTION
The definitions FILE_BEGIN, FILE_CURRENT and FILE_END need to be
provided for windows, too.

Simplify the preprocessor directives by taking common definitions (the
string and wstring typedefs) and harmless definitions (the S_OK, which
is already protected by its own #ifdef) out of #ifdef conditions.